### PR TITLE
WB-380 | Manual payment

### DIFF
--- a/lib/router.go
+++ b/lib/router.go
@@ -61,11 +61,11 @@ func (router RouteData) Router(w http.ResponseWriter, r *http.Request) {
 	}
 	if e != nil {
 		log.Println("Router error")
+		log.Println(e.Error())
 		// Temporary work-around while test-function is not rewritten
 		reader := strings.NewReader(`{"message":"` + e.Error() + `"}`)
 		io.Copy(w, reader)
 
-		// log.Println(e.Error())
 		// http.Error(w, e.Error(), 500)
 	}
 	if !isFound {

--- a/lib/router.go
+++ b/lib/router.go
@@ -61,9 +61,12 @@ func (router RouteData) Router(w http.ResponseWriter, r *http.Request) {
 	}
 	if e != nil {
 		log.Println("Router error")
-		log.Println(e.Error())
-		http.Error(w, e.Error(), 500)
+		// Temporary work-around while test-function is not rewritten
+		reader := strings.NewReader(`{"message":"` + e.Error() + `"}`)
+		io.Copy(w, reader)
 
+		// log.Println(e.Error())
+		// http.Error(w, e.Error(), 500)
 	}
 	if !isFound {
 		log.Println("Router not found")

--- a/payment/constants.go
+++ b/payment/constants.go
@@ -1,0 +1,7 @@
+package payment
+
+const (
+	ERR_TR_PAID         = "MPTR001: Transaction already paid."
+	ERR_TR_OUT_OF_ORDER = "MPTR002: Transaction is not next on schedule. Payment must be ordered."
+	ERR_PL_NOT_SIGNED   = "MPTR003: Policy not signed"
+)

--- a/payment/go.mod
+++ b/payment/go.mod
@@ -6,14 +6,19 @@ replace github.com/wopta/goworkspace/payment => ./
 
 require (
 	cloud.google.com/go v0.110.2
-	github.com/GoogleCloudPlatform/functions-framework-go v1.6.1
+	cloud.google.com/go/bigquery v1.51.1
+	github.com/GoogleCloudPlatform/functions-framework-go v1.7.3
 	github.com/google/uuid v1.3.0
+	github.com/wopta/goworkspace/document v1.0.59
 	github.com/wopta/goworkspace/lib v1.0.47
+	github.com/wopta/goworkspace/mail v1.0.21
 	github.com/wopta/goworkspace/models v1.0.95
+	github.com/wopta/goworkspace/policy v1.0.0
+	github.com/wopta/goworkspace/transaction v1.0.0
+	github.com/wopta/goworkspace/user v1.0.8
 )
 
 require (
-	cloud.google.com/go/bigquery v1.51.1 // indirect
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/firestore v1.9.0 // indirect
@@ -28,10 +33,12 @@ require (
 	github.com/apache/arrow/go/v12 v12.0.0 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.2 // indirect
-	github.com/cloudevents/sdk-go/v2 v2.6.1 // indirect
+	github.com/boombuler/barcode v1.0.1 // indirect
+	github.com/cloudevents/sdk-go/v2 v2.14.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-gota/gota v0.12.0 // indirect
+	github.com/go-pdf/fpdf v0.8.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -44,7 +51,9 @@ require (
 	github.com/googleapis/gax-go/v2 v2.8.0 // indirect
 	github.com/hyperjumptech/grule-rule-engine v1.12.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/johnfercher/maroto v0.41.0 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/jung-kurt/gofpdf v1.16.2 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
@@ -60,9 +69,12 @@ require (
 	github.com/pkg/sftp v1.13.5 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
+	github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/wopta/goworkspace/product v1.0.24 // indirect
+	github.com/wopta/goworkspace/wiseproxy v1.0.3 // indirect
 	github.com/xanzy/ssh-agent v0.2.1 // indirect
 	github.com/xuri/efp v0.0.0-20220603152613-6918739fd470 // indirect
 	github.com/xuri/excelize/v2 v2.7.0 // indirect
@@ -73,13 +85,14 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
+	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/time v0.1.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gonum.org/v1/gonum v0.11.0 // indirect

--- a/payment/manual.go
+++ b/payment/manual.go
@@ -1,26 +1,36 @@
 package payment
 
 import (
-	"fmt"
+	"encoding/base64"
+	"errors"
 	"io"
+	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/wopta/goworkspace/document"
 	"github.com/wopta/goworkspace/lib"
+	"github.com/wopta/goworkspace/mail"
 	"github.com/wopta/goworkspace/models"
+	"github.com/wopta/goworkspace/policy"
+	"github.com/wopta/goworkspace/transaction"
+	"github.com/wopta/goworkspace/user"
 )
 
-type ManualPayPayload struct {
+type ManualPaymentPayload struct {
 	PaymentMethod string `json:"paymentMethod"`
 	Note          string `json:"note"`
 }
 
-func ManualPay(w http.ResponseWriter, r *http.Request) (string, interface{}, error) {
+func ManualPaymentFx(w http.ResponseWriter, r *http.Request) (string, interface{}, error) {
+	log.Println("ManualPaymentFx")
 	body := lib.ErrorByte(io.ReadAll(r.Body))
 	defer r.Body.Close()
-	var payload ManualPayPayload
+	var payload ManualPaymentPayload
 
-	err := lib.CheckPayload[ManualPayPayload](body, &payload, []string{"paymentMethod"})
+	err := lib.CheckPayload[ManualPaymentPayload](body, &payload, []string{"paymentMethod"})
 	if err != nil {
 		return "", nil, err
 	}
@@ -30,32 +40,77 @@ func ManualPay(w http.ResponseWriter, r *http.Request) (string, interface{}, err
 	fireTransactions := lib.GetDatasetByEnv(origin, "transactions")
 	firePolicies := lib.GetDatasetByEnv(origin, "policy")
 
-	var transaction models.Transaction
-	var policy models.Policy
+	var t models.Transaction
+	var p models.Policy
 
 	docsnap, err := lib.GetFirestoreErr(fireTransactions, transactionUid)
 	if err != nil {
 		return "", nil, err
 	}
-	err = docsnap.DataTo(&transaction)
+	err = docsnap.DataTo(&t)
 	lib.CheckError(err)
 
-	if transaction.IsPay {
-		return "", nil, fmt.Errorf("Denied: Transaction %s already paid!", transactionUid)
+	if t.IsPay {
+		log.Printf("ManualPaymentFx ERROR: %s", ERR_TR_PAID)
+		return "", nil, errors.New(ERR_TR_PAID)
 	}
 
-	docsnap, err = lib.GetFirestoreErr(firePolicies, transaction.PolicyUid)
+	firePolicyTransactions := transaction.GetPolicyTransactions(origin, t.PolicyUid)
+	log.Printf("ManualPaymentFx: Found transactions %v", firePolicyTransactions)
+	var canPayTransaction = false
+
+	for _, t := range firePolicyTransactions {
+		if !t.IsPay && t.Uid != transactionUid {
+			log.Printf("ManualPaymentFx: Next transaction to be paid should be %s", t.Uid)
+			break
+		}
+		if t.Uid == transactionUid {
+			canPayTransaction = true
+			break
+		}
+	}
+
+	if !canPayTransaction {
+		log.Printf("ManualPaymentFx ERROR: %s", ERR_TR_OUT_OF_ORDER)
+		return "", nil, errors.New(ERR_TR_OUT_OF_ORDER)
+	}
+
+	docsnap, err = lib.GetFirestoreErr(firePolicies, t.PolicyUid)
 	if err != nil {
 		return "", nil, err
 	}
-	err = docsnap.DataTo(&policy)
+	err = docsnap.DataTo(&p)
 	lib.CheckError(err)
 
-	if !policy.IsSign {
-		return "", nil, fmt.Errorf("Denied: Policy %s not signed!", transaction.PolicyUid)
+	if !p.IsSign {
+		log.Printf("ManualPaymentFx ERROR: %s", ERR_PL_NOT_SIGNED)
+		return "", nil, errors.New(ERR_PL_NOT_SIGNED)
 	}
 
-	// Update transaction
+	ManualPayment(&t, origin, &payload)
+
+	// Update policy if needed
+	if !p.IsPay {
+		// Create/Update document on user collection based on contractor fiscalCode
+		user.SetUserIntoPolicyContractor(&p, origin)
+
+		// Get Policy contract
+		gsLink := <-document.GetFileV6(p, t.PolicyUid)
+		log.Println("Payment::contractGsLink: ", gsLink)
+
+		// Update Policy as paid
+		policy.SetPolicyPaid(&p, gsLink, origin)
+
+		// Send mail with the contract to the user
+		sendContractMail(&p)
+	}
+
+	return "", nil, nil
+}
+
+func ManualPayment(transaction *models.Transaction, origin string, payload *ManualPaymentPayload) {
+	fireTransactions := lib.GetDatasetByEnv(origin, "transactions")
+
 	transaction.ProviderName = "manual"
 	transaction.PaymentMethod = payload.PaymentMethod
 	transaction.PaymentNote = payload.Note
@@ -64,17 +119,21 @@ func ManualPay(w http.ResponseWriter, r *http.Request) (string, interface{}, err
 	transaction.Status = models.TransactionStatusPay
 	transaction.StatusHistory = append(transaction.StatusHistory, models.TransactionStatusPay)
 
-	lib.SetFirestore(fireTransactions, transactionUid, transaction)
+	lib.SetFirestore(fireTransactions, transaction.Uid, transaction)
 	transaction.BigQuerySave(origin)
+}
 
-	// Update policy if needed
-	if !policy.IsPay {
-		policy.IsPay = true
-		// update policy.NextPay ????
+func sendContractMail(policy *models.Policy) {
+	log.Printf("SendContractMail: %s", policy.Uid)
+	name := policy.Uid + ".pdf"
+	contractbyte, err := lib.GetFromGoogleStorage(os.Getenv("GOOGLE_STORAGE_BUCKET"), "assets/users/"+
+		policy.Contractor.Uid+"/contract_"+name)
+	lib.CheckError(err)
 
-		lib.SetFirestore(firePolicies, transaction.PolicyUid, &policy)
-		policy.BigquerySave(origin)
-	}
-
-	return "", nil, nil
+	mail.SendMailContract(*policy, &[]mail.Attachment{{
+		Byte:        base64.StdEncoding.EncodeToString(contractbyte),
+		ContentType: "application/pdf",
+		Name: policy.Contractor.Name + "_" + policy.Contractor.Surname + "_" +
+			strings.ReplaceAll(policy.NameDesc, " ", "_") + "_contratto.pdf",
+	}})
 }

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -24,7 +24,7 @@ func init() {
 
 func Payment(w http.ResponseWriter, r *http.Request) {
 
-	log.Println("Callback")
+	log.Println("Payment")
 	lib.EnableCors(&w, r)
 	w.Header().Set("Access-Control-Allow-Methods", "POST")
 	route := lib.RouteData{
@@ -56,7 +56,7 @@ func Payment(w http.ResponseWriter, r *http.Request) {
 			},
 			{
 				Route:   "/manual/v1/:transactionUid",
-				Handler: ManualPay,
+				Handler: ManualPaymentFx,
 				Method:  http.MethodPost,
 				Roles:   []string{models.UserRoleAdmin, models.UserRoleManager},
 			},


### PR DESCRIPTION
Update logic for allowing manual payment of single transaction:
- must not be paid;
- must be the next installment for the related policy;
- the policy must be signed

Update Policy if was not paid as in callback/payment:
- move contract and attach it to the policy
- create/update user
- update policy fields
- send email with the contract to the user

We've also update the global handling of errors on the router. Now instead of returning a status code 500 (that with the interception of the appcheck function arrives as a 200 at the Frontend), we return a 200 with an error message