### PR TITLE
[HOTFIX] Changed how we calculate the Wise policy price to have also the payment split

### DIFF
--- a/models/constants.go
+++ b/models/constants.go
@@ -41,6 +41,7 @@ type PaySplit string
 const (
 	PaySplitMonthly      PaySplit = "monthly"
 	PaySplitYear         PaySplit = "year"
+	PaySplitSemestral    PaySplit = "semestral"
 	PaySingleInstallment PaySplit = "singleInstallment"
 )
 

--- a/models/wise-complete-policy.go
+++ b/models/wise-complete-policy.go
@@ -87,14 +87,14 @@ func updatePolicyPrice(policy *Policy, wisePolicy *WiseCompletePolicy) {
 	if wisePolicy.Contract.InstalmentTypeCode == WiseMonthlyPaymentSplitCode {
 		policy.PaymentSplit = string(PaySplitMonthly)
 		policy.PriceGross = policy.PriceGrossMonthly * 12
-		policy.PriceNett = policy.PriceNett * 12
+		policy.PriceNett = policy.PriceNettMonthly * 12
 		policy.TaxAmount = policy.TaxAmountMonthly * 12
 		return
 	}
 	if wisePolicy.Contract.InstalmentTypeCode == WiseSemestralPaymentSplitCode {
 		policy.PaymentSplit = string(PaySplitSemestral)
 		policy.PriceGross = policy.PriceGrossMonthly * 2
-		policy.PriceNett = policy.PriceNett * 2
+		policy.PriceNett = policy.PriceNettMonthly * 2
 		policy.TaxAmount = policy.TaxAmountMonthly * 2
 		return
 	}

--- a/models/wise-complete-policy.go
+++ b/models/wise-complete-policy.go
@@ -32,7 +32,7 @@ func (wisePolicy *WiseCompletePolicy) ToDomain() Policy {
 	policy.Uid = fmt.Sprintf("wise:%d", wisePolicy.Id)
 	policy.Contractor = *wisePolicy.Contractors[0].Registry.ToDomain()
 	policy.CodeCompany = wisePolicy.PolicyNumber
-	
+
 	updatePolicyPrice(&policy, wisePolicy)
 
 	policy.ProductVersion = "v1"

--- a/models/wise-complete-policy.go
+++ b/models/wise-complete-policy.go
@@ -3,6 +3,8 @@ package models
 import (
 	"fmt"
 	"time"
+
+	"github.com/wopta/goworkspace/lib"
 )
 
 type WiseCompletePolicy struct {
@@ -25,13 +27,14 @@ func (wisePolicy *WiseCompletePolicy) ToDomain() Policy {
 		attachment Attachment
 	)
 
+	updatePolicyEndDate(&policy, wisePolicy)
+
 	policy.Uid = fmt.Sprintf("wise:%d", wisePolicy.Id)
 	policy.Contractor = *wisePolicy.Contractors[0].Registry.ToDomain()
-	policy.EndDate = wisePolicy.Contract.PolicyExpirationDate
 	policy.CodeCompany = wisePolicy.PolicyNumber
-	policy.PriceGross = wisePolicy.Contract.GrossAmount
-	policy.PriceNett = wisePolicy.Contract.NetAmount
-	policy.TaxAmount = wisePolicy.Contract.TaxesAmount
+	
+	updatePolicyPrice(&policy, wisePolicy)
+
 	policy.ProductVersion = "v1"
 
 	switch wisePolicy.ProductTypeCode {
@@ -57,6 +60,44 @@ func (wisePolicy *WiseCompletePolicy) ToDomain() Policy {
 	}
 
 	return policy
+}
+
+func updatePolicyEndDate(policy *Policy, wisePolicy *WiseCompletePolicy) {
+	location, err := time.LoadLocation("Europe/Rome")
+	lib.CheckError(err)
+	policyEndDate := wisePolicy.Contract.PolicyExpirationDate.In(location)
+	_, offset := policyEndDate.Zone()
+	policy.EndDate = policyEndDate.Add(time.Duration(time.Second * time.Duration(offset)))
+}
+
+func updatePolicyPrice(policy *Policy, wisePolicy *WiseCompletePolicy) {
+	policy.PriceGross = wisePolicy.Contract.AnnualGrossPrice
+	policy.PriceNett = wisePolicy.Contract.NetAmount
+	policy.TaxAmount = policy.PriceGross - policy.PriceNett
+
+	if wisePolicy.Contract.InstalmentTypeCode == WiseYearlyPaymentSplitCode {
+		policy.PaymentSplit = string(PaySplitYear)
+		return
+	}
+
+	policy.PriceGrossMonthly = wisePolicy.Contract.GrossAmount
+	policy.PriceNettMonthly = wisePolicy.Contract.NetAmount
+	policy.TaxAmountMonthly = policy.PriceGrossMonthly - policy.PriceNettMonthly
+
+	if wisePolicy.Contract.InstalmentTypeCode == WiseMonthlyPaymentSplitCode {
+		policy.PaymentSplit = string(PaySplitMonthly)
+		policy.PriceGross = policy.PriceGrossMonthly * 12
+		policy.PriceNett = policy.PriceNett * 12
+		policy.TaxAmount = policy.TaxAmountMonthly * 12
+		return
+	}
+	if wisePolicy.Contract.InstalmentTypeCode == WiseSemestralPaymentSplitCode {
+		policy.PaymentSplit = string(PaySplitSemestral)
+		policy.PriceGross = policy.PriceGrossMonthly * 2
+		policy.PriceNett = policy.PriceNett * 2
+		policy.TaxAmount = policy.TaxAmountMonthly * 2
+		return
+	}
 }
 
 type WiseBase64Annex struct {

--- a/models/wise-contract.go
+++ b/models/wise-contract.go
@@ -57,4 +57,11 @@ type WiseContract struct {
 	AnnualityStartDate                  time.Time `json:"dtInizioAnnualita,omitempty"`
 	AnnualityEndDate                    time.Time `json:"dtFineAnnualita,omitempty"`
 	IsExternal                          bool      `json:"bIddEsterno,omitempty"`
+	AnnualGrossPrice                    float64   `json:"nImpLordoAnnuo,omitempty"`
 }
+
+const (
+	WiseYearlyPaymentSplitCode = "01"
+	WiseSemestralPaymentSplitCode = "02"
+	WiseMonthlyPaymentSplitCode = "06"
+)

--- a/models/wise-contract.go
+++ b/models/wise-contract.go
@@ -61,7 +61,7 @@ type WiseContract struct {
 }
 
 const (
-	WiseYearlyPaymentSplitCode = "01"
+	WiseYearlyPaymentSplitCode    = "01"
 	WiseSemestralPaymentSplitCode = "02"
-	WiseMonthlyPaymentSplitCode = "06"
+	WiseMonthlyPaymentSplitCode   = "06"
 )

--- a/models/wise-guarantee.go
+++ b/models/wise-guarantee.go
@@ -48,8 +48,8 @@ func (wiseGuarantee *WiseGuarantee) ToDomain() Guarante {
 	}
 	guarantee.SumInsuredLimitOfIndemnity = wiseGuarantee.SumInsuredLimitOfIndemnity
 
+	var guaranteeValue GuaranteValue
 	for _, parameter := range wiseGuarantee.Parameters {
-		var guaranteeValue GuaranteValue
 		if strings.EqualFold(parameter.Name, "FRANCHIGIA") {
 			guaranteeValue.Deductible = parameter.Value
 		}
@@ -58,8 +58,8 @@ func (wiseGuarantee *WiseGuarantee) ToDomain() Guarante {
 				guaranteeValue.SumInsuredLimitOfIndemnity = value
 			}
 		}
-		guarantee.Value = &guaranteeValue
 	}
+	guarantee.Value = &guaranteeValue
 
 	return guarantee
 }


### PR DESCRIPTION
- Fixed problem in models/wise-guarantee.go, where the GuaranteeValue was being cleared because it was declared inside the for loop, and not outside as it should be
- Added semestral payment split because in wise we have some semestral policies and this will be visualized in app
- [TEMP] Added an offset to the policy EndDate (only for wise policies) so we can visualize the date correctly on the app. This requires a deeper understanding for all the dates, because we are saving them incorrectly.