### PR TITLE
[TG-318] edit network node struct

### DIFF
--- a/models/network-node.go
+++ b/models/network-node.go
@@ -42,6 +42,7 @@ type NetworkNode struct {
 	Data            string                `json:"-" firestore:"-" bigquery:"data"`
 	HasAnnex        bool                  `json:"hasAnnex" firestore:"hasAnnex" bigquery:"hasAnnex"`
 	Designation     string                `json:"designation" firestore:"designation" bigquery:"designation"`
+	ProponentUid    string                `json:"proponentUid" firestore:"proponentUid" bigquery:"-"`
 }
 
 type PartnershipNode struct {
@@ -60,6 +61,8 @@ type AgencyNode struct {
 	RuiRegistration    time.Time             `json:"ruiRegistration" firestore:"ruiRegistration" bigquery:"-"`
 	BigRuiRegistration bigquery.NullDateTime `json:"-" firestore:"-" bigquery:"ruiRegistration"`
 	Skin               *Skin                 `json:"skin,omitempty" firestore:"skin,omitempty" bigquery:"-"`
+	Pec                string                `json:"pec,omitempty" firestore:"pec,omitempty" bigquery:"-"`
+	Website            string                `json:"website,omitempty" firestore:"website,omitempty" bigquery:"-"`
 }
 
 type AgentNode struct {

--- a/models/network-node.go
+++ b/models/network-node.go
@@ -42,7 +42,8 @@ type NetworkNode struct {
 	Data            string                `json:"-" firestore:"-" bigquery:"data"`
 	HasAnnex        bool                  `json:"hasAnnex" firestore:"hasAnnex" bigquery:"hasAnnex"`
 	Designation     string                `json:"designation" firestore:"designation" bigquery:"designation"`
-	ProponentUid    string                `json:"proponentUid" firestore:"proponentUid" bigquery:"-"`
+	ProponentUid    string                `json:"proponentUid,omitempty" firestore:"proponentUid,omitempty" bigquery:"-"`
+	DistributorUid  string                `json:"distributorUid,omitempty" firestore:"distributorUid,omitempty" bigquery:"-"`
 }
 
 type PartnershipNode struct {


### PR DESCRIPTION
Added following fields to NetworkNode struct:

ProponentUid String
DistributorUid String
AgencyNode.Pec String
AgencyNode.Website String

These fields will not be written in a bigquery field but only in json field of the table networkNodes