### PR TITLE
HOTFIX: renew startData research filter consider annuity

### DIFF
--- a/policy/query-builder/query-builder.go
+++ b/policy/query-builder/query-builder.go
@@ -43,8 +43,8 @@ var (
 		"contractorName":    "(REGEXP_CONTAINS(LOWER(JSON_VALUE(**tableAlias**.data, '$.contractor.name')), LOWER(@%s)))",
 		"contractorSurname": "(REGEXP_CONTAINS(LOWER(JSON_VALUE(**tableAlias**.data, '$.contractor.surname')), LOWER(@%s)))",
 
-		"startDateFrom": "(**tableAlias**.startDate >= @%s)",
-		"startDateTo":   "(**tableAlias**.startDate <= @%s)",
+		"startDateFrom": "(DATE_ADD(**tableAlias**.startDate, INTERVAL **tableAlias**.annuity YEAR) >= @%s)",
+		"startDateTo":   "(DATE_ADD(**tableAlias**.startDate, INTERVAL **tableAlias**.annuity YEAR) <= @%s)",
 		"company":       "(**tableAlias**.company = LOWER(@%s))",
 		"product":       "(**tableAlias**.name = LOWER(@%s))",
 		"producerUid":   "(**tableAlias**.producerUid IN (%s))",


### PR DESCRIPTION
This PR addresses an issue in the RenewPolicy tab where searching by startDate did not account for the associated annuity. As a result, users had to input the original policy's startDate to fetch a renewal policy, which is counterintuitive. This fix ensures the query builder correctly considers the annuity when performing searches by startDate

To evaluate possible impacts on FE when showing the results (should we return startDate + annuity as startDate or add an annuity field to PolicyInfo struct)